### PR TITLE
Fixed link to Bibletext at Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Bibletext.co
 ============
 
-Demo: [https://bibletext-co.herokuapp.com/](https://bibletext-co.herokuapp.com/)
+Demo: [https://bibletext.herokuapp.com/](https://bibletext.herokuapp.com/)
 
 ## How to contribute
 Fork the project and send us a pull request :smile:


### PR DESCRIPTION
The README.md file directs to <i><strong>bibletext-co.herokuapp.com</strong></i> but no such app exists. The demo app is under construction at <i><strong>bibletext.herokuapp.com</i></strong>. This pull request fixes the link error in the file.
